### PR TITLE
Add MkDocs documentation site and CI build/publish

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Documentation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  release:
+    types: [created]
+
+jobs:
+  build-docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | bash
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv
+          uv sync --extra docs
+          uv pip install -e .
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'release'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy-docs:
+    if: github.event_name == 'release'
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![](https://img.shields.io/badge/python-3.10+-blue.svg)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3333987.svg)](https://doi.org/10.5281/zenodo.3333987)
 
+[![Docs](https://img.shields.io/badge/Docs-GSP--Py%20Site-3D9970?style=flat-square)](https://jacksonpradolima.github.io/gsp-py/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/gsppy.svg?style=flat-square)](https://pypi.org/project/gsppy/)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=jacksonpradolima_gsp-py&metric=bugs)](https://sonarcloud.io/summary/new_code?id=jacksonpradolima_gsp-py)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=jacksonpradolima_gsp-py&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=jacksonpradolima_gsp-py)
@@ -27,13 +28,14 @@ Sequence Pattern (GSP)** algorithm. Ideal for market basket analysis, temporal m
     - [❖ Clone Repository](#option-1-clone-the-repository)
     - [❖ Install via PyPI](#option-2-install-via-pip)
 4. [🛠️ Developer Installation](#developer-installation)
-5. [💡 Usage](#usage)
+5. [📖 Documentation](#documentation)
+6. [💡 Usage](#usage)
     - [✅ Example: Analyzing Sales Data](#example-analyzing-sales-data)
     - [📊 Explanation: Support and Results](#explanation-support-and-results)
-6. [🌟 Planned Features](#planned-features)
-7. [🤝 Contributing](#contributing)
-8. [📝 License](#license)
-9. [📖 Citation](#citation)
+7. [🌟 Planned Features](#planned-features)
+8. [🤝 Contributing](#contributing)
+9. [📝 License](#license)
+10. [📖 Citation](#citation)
 
 ---
 
@@ -198,6 +200,19 @@ make bench-big           # run large benchmark
 
 > [!NOTE]
 > Tox in this project uses the "tox-uv" plugin. When running `make tox` or `tox`, missing Python interpreters can be provisioned automatically via uv (no need to pre-install all versions). This makes local setup faster.
+
+## 📖 Documentation
+
+- **Live site:** https://jacksonpradolima.github.io/gsp-py/
+- **Build locally:**
+
+  ```bash
+  uv venv .venv
+  uv sync --extra docs
+  uv run mkdocs serve
+  ```
+
+The docs use MkDocs with the Material theme and mkdocstrings to render the Python API directly from docstrings.
 
 ## 💡 Usage
 

--- a/docs/acceleration.md
+++ b/docs/acceleration.md
@@ -1,0 +1,34 @@
+# Acceleration
+
+GSP-Py supports multiple acceleration backends for computing support counts. Backend selection can be controlled via the
+`backend` keyword argument on `GSP.search` or through the `GSPPY_BACKEND` environment variable.
+
+## Backends
+
+- **Rust (`rust`)**: Uses the optional `_gsppy_rust` PyO3 extension for fast support counting. This is attempted first
+  when running with the default `auto` backend.
+- **GPU (`gpu`)**: Experimental CuPy-backed singleton counting. Falls back to CPU for longer sequences.
+- **Python (`python`)**: Pure-Python implementation for environments without compiled extensions or GPUs.
+- **Auto (`auto`)**: Default behavior that tries Rust, then Python. When `GSPPY_BACKEND` is set to `gpu`, GPU handling is
+  preferred for singletons.
+
+## Environment variables
+
+- `GSPPY_BACKEND`: Chooses the backend (`auto`, `python`, `rust`, or `gpu`).
+
+## Installation tips
+
+- Install the Rust extension locally with `make rust-build` or include the `rust` extra when using uv:
+
+  ```bash
+  uv sync --extra rust
+  ```
+
+- Install GPU support with the `gpu` extra (ensure that the correct CuPy build for your CUDA/ROCm stack is selected):
+
+  ```bash
+  uv sync --extra gpu
+  ```
+
+If a backend is unavailable, the library automatically falls back to the pure-Python implementation unless an explicit
+backend is required.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,14 @@
+# API Reference
+
+## GSP
+
+::: gsppy.gsp.GSP
+    options:
+      members:
+        - __init__
+        - search
+      show_submodules: false
+
+## Acceleration utilities
+
+::: gsppy.accelerate.support_counts

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,21 @@
+# Benchmarks
+
+Benchmark scripts in the `benchmarks/` directory measure support-counting performance across backends.
+
+## Running benchmarks
+
+Use the provided Makefile targets to run common benchmarks:
+
+```bash
+make bench-small
+make bench-big
+```
+
+You can also run the Python benchmark script directly with custom parameters:
+
+```bash
+uv run --python .venv/bin/python --no-project \
+  python benchmarks/bench_support.py --n_tx 1000000 --tx_len 8 --vocab 50000 --min_support 0.2 --warmup
+```
+
+Adjust parameters to match your hardware. Large benchmarks can be resource-intensive.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,29 @@
+# Command-Line Interface
+
+The `gsppy` CLI runs the Generalized Sequential Pattern algorithm on transactions stored in JSON or CSV files.
+
+## Usage
+
+```bash
+gsppy --file transactions.json --min_support 0.3 --backend rust --verbose
+```
+
+### Options
+
+- `--file PATH` (required): Path to a JSON or CSV file containing transactions.
+- `--min_support FLOAT`: Minimum support threshold as a fraction of total transactions (default: `0.2`).
+- `--backend [auto|python|rust|gpu]`: Backend for support counting (default: `auto`).
+- `--verbose`: Enables verbose logging for debugging and progress visibility.
+
+## Example
+
+```bash
+cat <<'DATA' > sample.json
+[["A", "B", "C"], ["A", "C"], ["A", "B"]]
+DATA
+
+# Run with Rust acceleration if available
+GSPPY_BACKEND=rust gsppy --file sample.json --min_support 0.4
+```
+
+Results are printed to standard output, grouped by sequence length.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Contributions are welcome! Please review the repository's contribution guidelines and code-quality tools before
+submitting a pull request.
+
+## Development setup
+
+1. Install uv and create a virtual environment:
+
+   ```bash
+   uv venv .venv
+   uv sync --frozen --extra dev
+   uv pip install -e .
+   ```
+
+2. Run quality checks locally:
+
+   ```bash
+   uv run ruff check .
+   uv run pyright
+   uv run pytest -n auto
+   ```
+
+3. Optional: build the Rust extension for faster local testing:
+
+   ```bash
+   make rust-build
+   ```
+
+## Pull requests
+
+- Keep changes focused and include tests where practical.
+- Update documentation when user-facing behavior changes.
+- Ensure type hints remain accurate; see the [Typing](typing.md) page for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# GSP-Py Documentation
+
+Welcome to the official documentation for **GSP-Py**, a Python library that implements the Generalized Sequential
+Pattern (GSP) algorithm. Use this site to install the library, explore the CLI, and dive into accelerated backends.
+
+## Highlights
+
+- **Sequence mining** with support-based pruning and candidate generation.
+- **Optional acceleration** via Rust and GPU backends.
+- **Developer-friendly tools** including typed APIs and optional benchmarks.
+
+## Quickstart
+
+Install the package from PyPI and run a simple search:
+
+```bash
+pip install gsppy
+```
+
+```python
+from gsppy.gsp import GSP
+
+transactions = [
+    ["Bread", "Milk"],
+    ["Bread", "Diaper", "Beer", "Eggs"],
+    ["Milk", "Diaper", "Beer", "Coke"],
+]
+
+patterns = GSP(transactions).search(min_support=0.3)
+for level, freq_patterns in enumerate(patterns, start=1):
+    print(f"Level {level}: {freq_patterns}")
+```
+
+Continue to the [Usage](usage.md) guide for installation details and backend selection tips.

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,0 +1,10 @@
+# Typing
+
+GSP-Py ships with strict type checking to keep the API predictable.
+
+- **Type checker:** Pyright runs in `strict` mode (see `pyproject.toml`).
+- **Type hints:** Public functions annotate arguments and return values, making them compatible with mkdocstrings.
+- **Optional tools:** Mypy can be enabled locally via `uv run mypy` if desired.
+
+When adding new code, prefer explicit types over inference and keep public docstrings aligned with the annotated
+signatures so rendered API docs remain accurate.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,64 @@
+# Usage
+
+This guide walks through installation, dependency management with **uv**, and running the GSP algorithm.
+
+## Installation
+
+The recommended way to install GSP-Py is from PyPI:
+
+```bash
+pip install gsppy
+```
+
+Alternatively, clone the repository and install in editable mode:
+
+```bash
+git clone https://github.com/jacksonpradolima/gsp-py.git
+cd gsp-py
+uv venv .venv
+uv sync --frozen
+uv pip install -e .
+```
+
+## Running a search
+
+```python
+from gsppy.gsp import GSP
+
+transactions = [
+    ["A", "B", "C"],
+    ["A", "C"],
+    ["A", "B"],
+]
+
+model = GSP(transactions)
+frequent = model.search(min_support=0.5)
+print(frequent)
+```
+
+The `min_support` argument expects a fraction in the range `(0.0, 1.0]` and defaults to `0.2`.
+
+## Backend selection
+
+GSP-Py can accelerate support counting with optional backends:
+
+- **auto (default):** tries the Rust extension, falling back to Python.
+- **python:** uses the pure-Python implementation.
+- **rust:** requires the Rust extension to be installed.
+- **gpu:** experimental CuPy backend for singleton counting.
+
+Set the backend via keyword argument or environment variable:
+
+```bash
+GSPPY_BACKEND=rust gsppy --file transactions.json
+```
+
+## CLI helper
+
+Install the CLI entrypoint with the package:
+
+```bash
+pip install gsppy
+```
+
+Run `gsppy --help` to see available options, or read the [CLI page](cli.md) for examples.

--- a/gsppy/accelerate.py
+++ b/gsppy/accelerate.py
@@ -178,6 +178,17 @@ def support_counts(
               fall back to CPU for the rest
     - "python": force pure-Python fallback
     - otherwise: try Rust first and fall back to Python
+
+    Example:
+        Running a search with an explicit backend:
+
+        ```python
+        from gsppy.accelerate import support_counts
+
+        transactions = [("A", "B"), ("A", "C")]
+        candidates = [("A",), ("B",), ("A", "B")]
+        counts = support_counts(transactions, candidates, min_support_abs=1, backend="python")
+        ```
     """
     backend_sel = (backend or _env_backend()).lower()
 

--- a/gsppy/gsp.py
+++ b/gsppy/gsp.py
@@ -295,6 +295,22 @@ class GSP:
             - Information about the algorithm's start, intermediate progress (candidates filtered),
               and completion.
             - Status updates for each iteration until the algorithm terminates.
+
+        Example:
+            Basic usage with the default backend:
+
+            ```python
+            from gsppy.gsp import GSP
+
+            transactions = [
+                ["Bread", "Milk"],
+                ["Bread", "Diaper", "Beer", "Eggs"],
+                ["Milk", "Diaper", "Beer", "Coke"],
+            ]
+
+            gsp = GSP(transactions)
+            patterns = gsp.search(min_support=0.3)
+            ```
         """
         if not 0.0 < min_support <= 1.0:
             raise ValueError("Minimum support must be in the range (0.0, 1.0]")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: GSP-Py
+site_description: Documentation for the GSP-Py library
+site_url: https://jacksonpradolima.github.io/gsp-py/
+repo_url: https://github.com/jacksonpradolima/gsp-py
+repo_name: jacksonpradolima/gsp-py
+nav:
+  - Home: index.md
+  - Usage: usage.md
+  - CLI: cli.md
+  - API: api.md
+  - Acceleration: acceleration.md
+  - Benchmarks: benchmarks.md
+  - Contributing: contributing.md
+  - Typing: typing.md
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.instant
+    - content.code.copy
+    - content.tabs.link
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            show_root_heading: true
+            heading_level: 2
+            separate_signature: true
+            show_source: false
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jacksonpradolima/gsp-py
+markdown_extensions:
+  - admonition
+  - attr_list
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,13 @@ dev = [
     "ruff==0.14.10",
     "tox==4.32.0",
 ]
+docs = [
+    "mkdocs>=1.6,<2",
+    "mkdocs-gen-files>=0.5,<1",
+    "mkdocs-literate-nav>=0.6,<1",
+    "mkdocs-material>=9.5,<10",
+    "mkdocstrings[python]>=0.26,<0.27",
+]
 rust = [
     "maturin==1.10.2"
 ]


### PR DESCRIPTION
## Summary
- add MkDocs configuration and documentation pages for usage, CLI, API (via mkdocstrings), acceleration, benchmarks, contributing, and typing guidance
- add doc-friendly examples to the public API and introduce a docs optional dependency set for building the site
- add a documentation workflow to build docs on pull requests and publish to GitHub Pages on releases
- update the README with the live docs link, local MkDocs build instructions, and a documentation badge

## Testing
- `python -m compileall gsppy`
- `uv sync --extra docs --dry-run` *(fails locally due to proxy blocking access to PyPI; docs workflow still uses this command and should succeed in CI with network access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695084023f6083278736b0fd7970b766)