### PR TITLE
Update publish workflow to use sigstore 4.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: syft packages dist -o cyclonedx-json=dist/sbom.json
 
       - name: Install sigstore
-        run: python -m pip install "cryptography<42" sigstore==3.5.1
+        run: python -m pip install sigstore==4.1.0
 
       - name: Sign distributions
         run: |


### PR DESCRIPTION
## Summary
- bump sigstore to 4.1.0 in the publish workflow to align with current releases and resolve cryptography compatibility issues

## Testing
- not run (CI will cover)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b118d1a4832781fa318286748cfe)