### PR TITLE
ci: configure Dependabot uv ecosystem and optimize lock check to run on Python 3.12 only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -28,6 +28,7 @@ jobs:
           uv sync --frozen --extra dev
 
       - name: Check lockfile freshness
+        if: matrix.python-version == '3.12'
         run: |
           set -e
           if ! uv lock --check; then


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] The *pull request* title contains a meaningful title
  - Short and informative: serves as a summary
- [x] At least skimmed through the coding conventions used in the project
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) (N/A — project uses Ruff)
- [x] Performed a self-review of my own code
- [ ] The code is commented, particularly in hard-to-understand areas (N/A — CI/YAML only)
- [ ] The documentation associated was created or updated (N/A — no API changes)
- [x] The changes generate no new warnings
- [ ] Add tests that prove the change is effective or that the feature works (covered by existing CI)
- [ ] New and existing unit tests pass locally with the changes (validated in CI matrix)
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

---

# Contents of the *Pull Request*

This PR updates CI and Dependabot to align with `uv` best practices:

- Configure Dependabot for the `uv` ecosystem and remove `pip`, so Dependabot PRs include and sync `uv.lock` directly.
  - Changed: [.github/dependabot.yml](.github/dependabot.yml)
- Optimize the lockfile freshness check to run only on Python 3.12 within the matrix.
  - Changed: [.github/workflows/code_quality.yml](.github/workflows/code_quality.yml)
  - Added `if: matrix.python-version == '3.12'` on the “Check lockfile freshness” step.
- No functional Python code changes; CI/dependency automation only.

Expected impact:
- Existing `pip` Dependabot PRs will no longer be updated — please close them.
- New and existing `uv` Dependabot PRs will include `uv.lock` updates, reducing noise from lockfile check failures.

# Stacked PR Chains (Optional)

None; this PR is standalone.

# How Has This Been Tested? (Required)

Validation via GitHub Actions:
- “Code Quality” workflow runs across the matrix (3.10–3.13) using `uv run` for `pytest`, `ty`, and `pyright`.
- The lockfile check (`uv lock --check`) executes only on 3.12.
- Dependabot with `uv` will open weekly PRs containing `pyproject.toml` and `uv.lock` updates.

Reproduction steps on this PR:
- Open/update this PR and confirm in logs:
  - “Check lockfile freshness” runs only on 3.12.
  - “uv run pytest”, “uv run ty check .”, and “uv run pyright” run across all versions and pass.
- For `uv` Dependabot PRs, request refresh if needed with “@dependabot recreate” or “@dependabot rebase”.

- [x] Test A: Run “Code Quality” on this PR; confirm matrix success and lock check on 3.12.
- [ ] Test B: (Optional) Trigger “Re-run Dependabot” to generate a `uv` PR and verify `uv.lock` is synced.

**Test Configuration**:
* Firmware version: N/A
* Hardware: GitHub-hosted runners
* Toolchain: `uv`, `pytest`, `ty`, `pyright`, `actions/checkout`, `astral-sh/setup-uv`
* SDK: N/A

# Other Notes

- Project uses Ruff instead of flake8; lint checks are handled accordingly.
- Changes focus on CI reliability and cost: fewer lockfile-related failures and cleaner Dependabot updates.
- Files touched:
  - [.github/dependabot.yml](.github/dependabot.yml)
  - [.github/workflows/code_quality.yml](.github/workflows/code_quality.yml)
