### PR TITLE
Add release workflow and Commitizen config for changelog-driven tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Create release from conventional commits
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump version, tag, and publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.0.0
+        with:
+          python-version: "3.x"
+
+      - name: Install Commitizen
+        run: |
+          python -m pip install --upgrade pip
+          pip install commitizen
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and update changelog
+        id: bump
+        run: |
+          cz bump --yes --changelog
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push version bump and tags
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git push --follow-tags
+
+      - name: Collect release metadata
+        if: steps.bump.outputs.changed == 'true'
+        id: release_data
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          changelog = Path("CHANGELOG.md").read_text()
+          pattern = re.compile(rf"^## \\[v{re.escape(version)}\\].*?$\\n(?P<body>.*?)(?=^## \\[v|\\Z)", re.M | re.S)
+          match = pattern.search(changelog)
+          body = match.group("body").strip() if match else f"Release v{version}"
+          release_notes = f"## v{version}\\n\\n{body}\\n"
+          Path("release_notes.md").write_text(release_notes)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"version={version}\\n")
+          PY
+
+      - name: Create GitHub release
+        if: steps.bump.outputs.changed == 'true'
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.2.1
+        with:
+          tag_name: v${{ steps.release_data.outputs.version }}
+          body_path: release_notes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,3 +182,13 @@ strip = true
 compatibility = "manylinux_2_28"
 python-packages = ["gsppy"]
 python-source = "."
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "3.3.0"
+tag_format = "v$version"
+changelog_file = "CHANGELOG.md"
+update_changelog_on_bump = true
+version_files = [
+    "pyproject.toml:version",
+]


### PR DESCRIPTION
### Motivation
- Automate release management so conventional commits can drive version bumps, changelog updates, Git tags, and GitHub releases with structured release notes.

### Description
- Add `[tool.commitizen]` settings to `pyproject.toml` to enable `cz_conventional_commits`, set `tag_format`, point at `CHANGELOG.md`, and declare `pyproject.toml:version` as the version file.
- Add `.github/workflows/release.yml` which triggers on `push` to `main`/`master` and `workflow_dispatch`, checks out with `fetch-depth: 0`, sets up Python, installs `commitizen`, and configures a Git author for automation.
- The workflow runs `cz bump --yes --changelog`, determines whether the repo changed, pushes version bumps and tags when present, extracts the new `version` from `pyproject.toml`, parses the corresponding entry from `CHANGELOG.md` into `release_notes.md`, and creates a GitHub release using `softprops/action-gh-release`.
- The workflow uses `tomllib` and a regex inside a small Python step to build release notes from the changelog and conditionally run push/release steps based on the `cz bump` result.

### Testing
- No automated tests were run for these configuration and workflow changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751b7e1f048327aa29ff787bc4446d)